### PR TITLE
[docs] Point to React Native docs directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Lottie is a mobile library for Android and iOS that parses [Adobe After Effects]
 
 For the first time, designers can create **and ship** beautiful animations without an engineer painstakingly recreating it by hand. They say a picture is worth 1,000 words so here are 13,000:
 
-# View documentation, FAQ, help, examples, and more at [airbnb.io/lottie](http://airbnb.io/lottie/)
+# View documentation, FAQ, help, examples, and more at [airbnb.io/lottie](http://airbnb.io/lottie/react-native/react-native.html)
 
 ![Example1](docs/gifs/Example1.gif)
 


### PR DESCRIPTION
A number of developers find it painful to find the docs. This can help them a bit.