### PR TITLE
make Lottie view use the json string directly

### DIFF
--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -89,12 +89,7 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
 
   @ReactProp(name = "sourceJson")
   public void setSourceJson(LottieAnimationView view, String json) {
-    try {
-        view.setAnimation(new JSONObject(json));
-    } catch (Exception e) {
-      // TODO: expose this to the user better. maybe an `onError` event?
-      Log.e(TAG,"setSourceJsonError", e);
-    }
+    view.setAnimationFromJson(json);
   }
 
   @ReactProp(name = "resizeMode")


### PR DESCRIPTION
This way may cause NPE： `view.setAnimation(new JSONObject(json));`
 I think the JSONObject can make json format, so the order changed. And parsing depends on this order。
The NPE log is,
```
E/AndroidRuntime(24975): java.lang.NullPointerException
E/AndroidRuntime(24975):        at com.airbnb.lottie.animation.content.BaseStrokeContent.<init>(BaseStrokeContent.java:63)
E/AndroidRuntime(24975):        at com.airbnb.lottie.animation.content.StrokeContent.<init>(StrokeContent.java:26)
E/AndroidRuntime(24975):        at com.airbnb.lottie.model.content.ShapeStroke.toContent(ShapeStroke.java:77)
E/AndroidRuntime(24975):        at com.airbnb.lottie.animation.content.ContentGroup.contentsFromModels(ContentGroup.java:30)
E/AndroidRuntime(24975):        at com.airbnb.lottie.animation.content.ContentGroup.<init>(ContentGroup.java:60)
E/AndroidRuntime(24975):        at com.airbnb.lottie.model.content.ShapeGroup.toContent(ShapeGroup.java:29)
E/AndroidRuntime(24975):        at com.airbnb.lottie.animation.content.ContentGroup.contentsFromModels(ContentGroup.java:30)
E/AndroidRuntime(24975):        at com.airbnb.lottie.animation.content.ContentGroup.<init>(ContentGroup.java:60)
E/AndroidRuntime(24975):        at com.airbnb.lottie.model.layer.ShapeLayer.<init>(ShapeLayer.java:25)
E/AndroidRuntime(24975):        at com.airbnb.lottie.model.layer.BaseLayer.forModel(BaseLayer.java:46)
E/AndroidRuntime(24975):        at com.airbnb.lottie.model.layer.CompositionLayer.<init>(CompositionLayer.java:52)
E/AndroidRuntime(24975):        at com.airbnb.lottie.LottieDrawable.buildCompositionLayer(LottieDrawable.java:236)
E/AndroidRuntime(24975):        at com.airbnb.lottie.LottieDrawable.setComposition(LottieDrawable.java:198)
E/AndroidRuntime(24975):        at com.airbnb.lottie.LottieAnimationView.setComposition(LottieAnimationView.java:488)
E/AndroidRuntime(24975):        at com.airbnb.lottie.LottieAnimationView$1.onCompositionLoaded(LottieAnimationView.java:81)
E/AndroidRuntime(24975):        at com.airbnb.lottie.parser.AsyncCompositionLoader.onPostExecute(AsyncCompositionLoader.java:29)
E/AndroidRuntime(24975):        at com.airbnb.lottie.parser.AsyncCompositionLoader.onPostExecute(AsyncCompositionLoader.java:12)
.....
```