### PR TITLE
Preserve content mode when animation view is replaced

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "src/js",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
+    "prepare": "npm run build",
     "build": "babel src/js --out-dir lib",
     "watch": "babel src/js --out-dir lib --watch",
     "build:pods": "cd example/ios; bundle exec pod install; cd -",

--- a/src/ios/LottieReactNative/LRNContainerView.m
+++ b/src/ios/LottieReactNative/LRNContainerView.m
@@ -96,13 +96,15 @@
 # pragma mark Private
 
 - (void)replaceAnimationView:(LOTAnimationView *)next {
+  UIViewContentMode contentMode = UIViewContentModeScaleAspectFit;
   if (_animationView != nil) {
+    contentMode = _animationView.contentMode;
     [_animationView removeFromSuperview];
   }
   _animationView = next;
   [self addSubview: next];
   [_animationView reactSetFrame:self.frame];
-  [_animationView setContentMode:UIViewContentModeScaleAspectFit];
+  [_animationView setContentMode:contentMode];
   [self applyProperties];
 }
 


### PR DESCRIPTION
Because we're setting the content mode directly on `_animationView` (see commit 89775d9f6e2b7d768771f43b62454c0d154412c3), we need to copy it when the animation view is replaced.