### PR TITLE
Clear animationJson property to resolve Android flickering issues

### DIFF
--- a/example/js/ExamplePicker.js
+++ b/example/js/ExamplePicker.js
@@ -22,9 +22,7 @@ export default class ExamplePicker extends React.Component {
           }),
         }}
       >
-        {Object.keys(this.props.examples)
-          .map(name => this.props.examples[name])
-          .map(ex => <Picker.Item key={ex.name} label={ex.name} value={ex.name} />)}
+        {this.props.examples.map(ex => <Picker.Item key={ex.name} label={ex.name} value={ex} />)}
       </Picker>
     );
   }

--- a/example/js/LottieAnimatedExample.js
+++ b/example/js/LottieAnimatedExample.js
@@ -33,17 +33,13 @@ const EXAMPLES = [
   makeExample('Twitter Heart', () => require('./animations/TwitterHeart.json')),
   makeExample('Watermelon', () => require('./animations/Watermelon.json')),
   makeExample('Motion Corpse', () => require('./animations/MotionCorpse-Jrcanest.json')),
-].reduce((acc, e) => {
-  // eslint-disable-next-line no-param-reassign
-  acc[e.name] = e;
-  return acc;
-}, {});
+];
 
 export default class LottieAnimatedExample extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      example: Object.keys(EXAMPLES)[0],
+      example: EXAMPLES[0],
       duration: 3000,
       isPlaying: true,
       isInverse: false,
@@ -73,6 +69,7 @@ export default class LottieAnimatedExample extends React.Component {
           toValue: 1,
           duration: this.state.duration,
           easing: Easing.linear,
+          useNativeDriver: true,
         }).start(({ finished }) => {
           if (finished) {
             this.setState({ isPlaying: false });
@@ -97,26 +94,22 @@ export default class LottieAnimatedExample extends React.Component {
 
   render() {
     const { duration, isPlaying, isInverse, progress, loop, example } = this.state;
-    const selectedExample = EXAMPLES[example];
     return (
       <View style={{ flex: 1 }}>
         <ExamplePicker
           example={example}
           examples={EXAMPLES}
-          onChange={e => {
+          onChange={(e, index) => {
             this.stopAnimation();
-            this.setState({ example: e });
+            this.setState({ example: EXAMPLES[index] });
           }}
         />
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
           <LottieView
             ref={this.setAnim}
-            autoPlay
-            style={[
-              selectedExample.width && { width: selectedExample.width },
-              isInverse && styles.lottieViewInvse,
-            ]}
-            source={selectedExample.getJson()}
+            autoPlay={!progress}
+            style={[example.width && { width: example.width }, isInverse && styles.lottieViewInvse]}
+            source={example.getJson()}
             progress={progress}
             loop={loop}
             enableMergePathsAndroidForKitKatAndAbove

--- a/example/js/LottieAnimatedExample.js
+++ b/example/js/LottieAnimatedExample.js
@@ -36,23 +36,13 @@ const EXAMPLES = [
 ];
 
 export default class LottieAnimatedExample extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      example: EXAMPLES[0],
-      duration: 3000,
-      isPlaying: true,
-      isInverse: false,
-      loop: true,
-    };
-    this.onValueChange = this.onValueChange.bind(this);
-    this.onInversePress = this.onInversePress.bind(this);
-    this.setAnim = this.setAnim.bind(this);
-  }
-
-  onValueChange(value) {
-    this.state.progress.setValue(value);
-  }
+  state = {
+    example: EXAMPLES[0],
+    duration: 3000,
+    isPlaying: true,
+    isInverse: false,
+    loop: true,
+  };
 
   manageAnimation = shouldPlay => {
     if (!this.state.progress) {
@@ -70,10 +60,8 @@ export default class LottieAnimatedExample extends React.Component {
           duration: this.state.duration,
           easing: Easing.linear,
           useNativeDriver: true,
-        }).start(({ finished }) => {
-          if (finished) {
-            this.setState({ isPlaying: false });
-          }
+        }).start(() => {
+          this.setState({ isPlaying: false });
         });
       }
     }
@@ -84,13 +72,13 @@ export default class LottieAnimatedExample extends React.Component {
   onPlayPress = () => this.manageAnimation(!this.state.isPlaying);
   stopAnimation = () => this.manageAnimation(false);
 
-  onInversePress() {
-    this.setState(state => ({ isInverse: !state.isInverse }));
-  }
+  onInversePress = () => this.setState(state => ({ isInverse: !state.isInverse }));
+  onProgressChange = progress => this.state.progress.setValue(progress);
+  onDurationChange = duration => this.setState({ duration });
 
-  setAnim(anim) {
+  setAnim = anim => {
     this.anim = anim;
-  }
+  };
 
   render() {
     const { duration, isPlaying, isInverse, progress, loop, example } = this.state;
@@ -177,10 +165,11 @@ export default class LottieAnimatedExample extends React.Component {
               <Text>Duration: ({Math.round(duration)}ms)</Text>
             </View>
             <Slider
+              step={50}
               minimumValue={50}
               maximumValue={4000}
               value={duration}
-              onValueChange={d => this.setState({ duration: d })}
+              onValueChange={this.onDurationChange}
               disabled={!progress}
             />
           </View>

--- a/example/js/LottieAnimatedExample.js
+++ b/example/js/LottieAnimatedExample.js
@@ -14,6 +14,8 @@ import {
 import LottieView from 'lottie-react-native';
 import ExamplePicker from './ExamplePicker';
 
+const AnimatedSlider = Animated.createAnimatedComponent(Slider);
+
 const playIcon = require('./images/play.png');
 const pauseIcon = require('./images/pause.png');
 const loopIcon = require('./images/loop.png');
@@ -169,11 +171,10 @@ export default class LottieAnimatedExample extends React.Component {
             <View>
               <Text>Progress:</Text>
             </View>
-            <Slider
+            <AnimatedSlider
               minimumValue={0}
               maximumValue={1}
-              // eslint-disable-next-line no-underscore-dangle
-              value={progress ? progress.__getValue() : 0}
+              value={progress || 0}
               onValueChange={this.onProgressChange}
               disabled={!progress}
             />

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
@@ -101,6 +101,7 @@ public class LottieAnimationViewPropertyManager {
 
     if (animationJson != null) {
       view.setAnimation(new JsonReader(new StringReader(animationJson)));
+      animationJson = null;
     }
 
     if (animationNameDirty) {


### PR DESCRIPTION
When controlling animation progress using `Animated.Value` Lottie animation was flickering with Android. Did some investigation and it seems that `animationJson` was parsed and applied every time any property change would happen. Setting animation only once solved that issue.

Also examples seemed to be broken when imperative API was disabled so fixed progress slider and cleaned up some example code.

Probably resolves #362