### PR TITLE
Remove Gradle warning

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -26,6 +26,6 @@ android {
 }
 
 dependencies {
-  provided "com.facebook.react:react-native:+"
-  compile 'com.airbnb.android:lottie:2.5.5'
+  compileOnly "com.facebook.react:react-native:+"
+  implementation 'com.airbnb.android:lottie:2.5.5'
 }


### PR DESCRIPTION
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html