### PR TITLE
Fixed typescript type publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.5.8",
   "description": "React Native bindings for Lottie",
   "main": "lib/index.js",
-  "types": "src/js",
+  "types": "src/js/index.d.ts",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "prepare": "npm run build",


### PR DESCRIPTION
For some reason, different versions of typescript can find the type definition when
the folder is specified, but some compilers and editors (such as vscode) does not like this

Using the specific file instead as I could not find any flow description in here.