### PR TITLE
Fixed typescript type definition export for 3.x

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -106,5 +106,5 @@ declare module "lottie-react-native" {
     reset(): void;
   }
 
-  export = AnimatedLottieView;
+  export default AnimatedLottieView;
 }


### PR DESCRIPTION
This contribution is pretty simple, the type definition was using a syntax that isn't compatible with es6 (which is typescript's default syntax).

I am not sure why I didn't have this issue before, but noticed it on one of my build servers the type definition was failing as `export = SomeClass;` isn't really supported, instead it needs to use `export default SomeClass;`

Hope to see this change in trunk soon :)