### PR TITLE
This change removes the deprecation warning received whilst compiling Android

### DIFF
--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
@@ -4,6 +4,7 @@ import android.util.JsonReader;
 import android.widget.ImageView;
 
 import com.airbnb.lottie.LottieAnimationView;
+import com.airbnb.lottie.LottieDrawable;
 
 import java.io.StringReader;
 import java.lang.ref.WeakReference;
@@ -115,7 +116,7 @@ public class LottieAnimationViewPropertyManager {
     }
 
     if (loop != null) {
-      view.loop(loop);
+      view.setRepeatCount(loop ? LottieDrawable.INFINITE : 0);
       loop = null;
     }
 


### PR DESCRIPTION
Basically, stopped using view.loop(true or false) to use view.setRepeatCount(INFINITE or 0)
which, can be extended in the future (removing loop for setRepeatCount directly)