### PR TITLE
fix: android build error - replace 'implementation' with 'api'

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -27,5 +27,5 @@ android {
 
 dependencies {
   compileOnly "com.facebook.react:react-native:+"
-  implementation 'com.airbnb.android:lottie:2.5.5'
+  api 'com.airbnb.android:lottie:2.5.5'
 }


### PR DESCRIPTION
error msg:
```
* What went wrong:
Execution failed for task ':app:preDebugBuild'.
> Android dependency 'com.android.support:appcompat-v7' has different version for the compile (26.1.0) and runtime (27.1.1) classpath. You should manually set the same version via DependencyResolution
```