### PR TITLE
Use commonjs object export compatible syntax

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -124,5 +124,5 @@ declare module "lottie-react-native" {
     reset(): void;
   }
 
-  export default AnimatedLottieView;
+  export = AnimatedLottieView;
 }


### PR DESCRIPTION
The js file does not have a default export.
The typescript mechanism for a function or class commonjs `module.exports` is `export =`.